### PR TITLE
feat(build): add support for windows filesystem

### DIFF
--- a/src/AureliaDependenciesPlugin.ts
+++ b/src/AureliaDependenciesPlugin.ts
@@ -44,7 +44,7 @@ class ParserPlugin {
     parser.plugin("evaluate Identifier imported var.moduleName", (expr: Webpack.MemberExpression) => {
       if (expr.property.name === "moduleName" &&
           expr.object.name === "PLATFORM" &&
-          expr.object.type.toString() === "Identifier") {
+          String(expr.object.type) === "Identifier") {
         return new BasicEvaluatedExpression().setIdentifier("PLATFORM.moduleName").setRange(expr.range);
       }
       return undefined;
@@ -58,8 +58,8 @@ class ParserPlugin {
     //    PLATFORM.moduleName("id");
     parser.plugin("evaluate MemberExpression", (expr: Webpack.MemberExpression) => {
       if (expr.property.name === "moduleName" &&
-         (expr.object.type === "MemberExpression" && expr.object.property.name === "PLATFORM" ||
-          expr.object.type.toString() === "Identifier" && expr.object.name === "PLATFORM")) {
+         (String(expr.object.type) === "MemberExpression" && expr.object.property.name === "PLATFORM" ||
+          String(expr.object.type) === "Identifier" && expr.object.name === "PLATFORM")) {
         return new BasicEvaluatedExpression().setIdentifier("PLATFORM.moduleName").setRange(expr.range);
       }
       return undefined;

--- a/src/AureliaDependenciesPlugin.ts
+++ b/src/AureliaDependenciesPlugin.ts
@@ -44,7 +44,7 @@ class ParserPlugin {
     parser.plugin("evaluate Identifier imported var.moduleName", (expr: Webpack.MemberExpression) => {
       if (expr.property.name === "moduleName" &&
           expr.object.name === "PLATFORM" &&
-          expr.object.type === "Identifier") {
+          expr.object.type.toString() === "Identifier") {
         return new BasicEvaluatedExpression().setIdentifier("PLATFORM.moduleName").setRange(expr.range);
       }
       return undefined;
@@ -59,7 +59,7 @@ class ParserPlugin {
     parser.plugin("evaluate MemberExpression", (expr: Webpack.MemberExpression) => {
       if (expr.property.name === "moduleName" &&
          (expr.object.type === "MemberExpression" && expr.object.property.name === "PLATFORM" ||
-          expr.object.type === "Identifier" && expr.object.name === "PLATFORM")) {
+          expr.object.type.toString() === "Identifier" && expr.object.name === "PLATFORM")) {
         return new BasicEvaluatedExpression().setIdentifier("PLATFORM.moduleName").setRange(expr.range);
       }
       return undefined;

--- a/src/PreserveModuleNamePlugin.ts
+++ b/src/PreserveModuleNamePlugin.ts
@@ -56,6 +56,7 @@ export class PreserveModuleNamePlugin {
           }
 
           // Metadata?
+          moduleId = moduleId.replace(/\\/g, '/');
           if (module.meta) {
             module.meta['aurelia-id'] = moduleId;
           }
@@ -148,11 +149,22 @@ function getNodeModuleData(module: Webpack.Module): NodeModule.Data | null {
     return null;
   }
 
+  function cleanWindowsPaths(paths: RegExpMatchArray | null) {
+    var out: string[] = [];
+    if (!paths) {
+      return out;
+    }
+    for (var i = 0; i < paths.length; i += 1) {
+      out[i] = paths[i].replace(':', '').split('\\').join('/');
+    }
+    return out;
+  }
+
   // Note that the negative lookahead (?!.*node_modules) ensures that we only match the last node_modules/ folder in the path,
   // in case the package was located in a sub-node_modules (which can occur in special circumstances).
   // We also need to take care of scoped modules. If the name starts with @ we must keep two parts,
   // so @corp/bar is the proper module name.
-  const modulePaths = module.resource.match(/(.*\bnode_modules[\\/](?!.*\bnode_modules\b)((?:@[^\\/]+[\\/])?[^\\/]+))(.*)/i);
+  const modulePaths = cleanWindowsPaths(module.resource.match(/(.*\bnode_modules[\\/](?!.*\bnode_modules\b)((?:@[^\\/]+[\\/])?[^\\/]+))(.*)/i));
   if (!modulePaths || modulePaths.length !== 4) {
     return null;
   }

--- a/src/PreserveModuleNamePlugin.ts
+++ b/src/PreserveModuleNamePlugin.ts
@@ -149,22 +149,11 @@ function getNodeModuleData(module: Webpack.Module): NodeModule.Data | null {
     return null;
   }
 
-  function cleanWindowsPaths(paths: RegExpMatchArray | null) {
-    var out: string[] = [];
-    if (!paths) {
-      return out;
-    }
-    for (var i = 0; i < paths.length; i += 1) {
-      out[i] = paths[i].replace(':', '').split('\\').join('/');
-    }
-    return out;
-  }
-
   // Note that the negative lookahead (?!.*node_modules) ensures that we only match the last node_modules/ folder in the path,
   // in case the package was located in a sub-node_modules (which can occur in special circumstances).
   // We also need to take care of scoped modules. If the name starts with @ we must keep two parts,
   // so @corp/bar is the proper module name.
-  const modulePaths = cleanWindowsPaths(module.resource.match(/(.*\bnode_modules[\\/](?!.*\bnode_modules\b)((?:@[^\\/]+[\\/])?[^\\/]+))(.*)/i));
+  const modulePaths = module.resource.match(/(.*\bnode_modules[\\/](?!.*\bnode_modules\b)((?:@[^\\/]+[\\/])?[^\\/]+))(.*)/i);
   if (!modulePaths || modulePaths.length !== 4) {
     return null;
   }


### PR DESCRIPTION
When building on the Windows filesystem back-slashes were being used for
file paths and module ids.  The back-slashes were being escaped but in
the case of modules that start with the letter 'u' ended up being
interpreted as starting a unicode character.  To fix this we are
replacing back-slashes with forward-slashes in module paths and module
ids.

This is believed to be a non-breaking change.